### PR TITLE
dutil: Add SleepWithContext

### DIFF
--- a/dutil/time.go
+++ b/dutil/time.go
@@ -1,0 +1,44 @@
+package dutil
+
+import (
+	"context"
+	"time"
+)
+
+// sleepTestHook is a hook that SleepWithContext calls, that lets us
+// insert a pause in order to more reliably test a certain race
+// condition.
+var sleepTestHook func()
+
+// Sleep pauses the current goroutine for at least the duration d, or
+// until the Context is done, whichever happens first.
+//
+// You may be thinking, why not just do:
+//
+//     select {
+//     case <-ctx.Done():
+//     case <-time.After(d):
+//     }
+//
+// well, time.After can't get garbage collected until the timer
+// expires, even if the Context is done.  What this function provides
+// is properly stopping the timer so that it can be garbage collected
+// sooner.
+//
+// https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082
+func SleepWithContext(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	timer := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		if sleepTestHook != nil {
+			sleepTestHook()
+		}
+		if !timer.Stop() {
+			<-timer.C
+		}
+	case <-timer.C:
+	}
+}

--- a/dutil/time_test.go
+++ b/dutil/time_test.go
@@ -1,0 +1,64 @@
+package dutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/datawire/dlib/dlog"
+)
+
+func assertDurationEq(t testing.TB, expected, actual, slop time.Duration, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	diff := expected - actual
+	if diff < 0 {
+		diff = -diff
+	}
+
+	if diff > slop {
+		return assert.Fail(t,
+			fmt.Sprintf("Expected duration to be within %v of %v, but was %v", slop, expected, actual),
+			msgAndArgs...)
+	}
+
+	return true
+}
+
+func TestSleep(t *testing.T) {
+
+	testcases := map[string]struct {
+		Arg         time.Duration
+		CancelAfter time.Duration
+		Expected    time.Duration
+		Hook        func()
+	}{
+		"negative":    {Arg: -1 * time.Hour, Expected: 0},
+		"zero":        {Arg: 0, Expected: 0},
+		"canceled":    {Arg: 1 * time.Hour, CancelAfter: 1 * time.Second, Expected: 1 * time.Second},
+		"normal":      {Arg: 1 * time.Second, Expected: 1 * time.Second},
+		"late-cancel": {Arg: 1 * time.Second, CancelAfter: 1 * time.Hour, Expected: 1 * time.Second},
+		"race": {Arg: 11 * (time.Second / 10), CancelAfter: 1 * time.Second,
+			Hook:     func() { time.Sleep(time.Second / 2) },
+			Expected: 3 * (time.Second / 2)},
+	}
+	for tcname, tcinfo := range testcases {
+		t.Run(tcname, func(t *testing.T) {
+			ctx := dlog.NewTestContext(t, false)
+			if tcinfo.CancelAfter > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tcinfo.CancelAfter)
+				defer cancel()
+			}
+			sleepTestHook = tcinfo.Hook
+			start := time.Now()
+			SleepWithContext(ctx, tcinfo.Arg)
+			actual := time.Since(start)
+			assertDurationEq(t, tcinfo.Expected, actual,
+				time.Second/100)
+		})
+	}
+}


### PR DESCRIPTION
I saw [a Medium post](https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082) today about memory leaks when using `time.After()`, and thought "oh no, I/we use `time.After` all over the place as a cancel-able `time.Sleep`, I'd better figure out how to do it the right way, and put that somewhere shared!"