### PR TITLE
CI: Check that generated files are up-to-date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,26 @@
 version: 2.1
 
+commands:
+
+  "dirty-check":
+    steps:
+      - run:
+          name: "Dirty check"
+          command: |
+            # On Windows, `git status` doesn't record no-op
+            # line-ending changes in to the index, so things show as
+            # dirty even if they aren't.  Trying to `add` them does
+            # trigger the appropriate index update.  So do a `git add`
+            # *before* the `git status --porcelain` to work around
+            # Windows being terrible; we'd otherwise put the `git add`
+            # inside of the `if` block to help generate better output
+            # for `git diff`.
+            git add .
+            if [[ -n "$(git status --porcelain)" ]]; then
+               PAGER= git diff --cached
+               exit 1
+            fi
+
 jobs:
 
   "test":
@@ -27,9 +48,20 @@ jobs:
     - checkout
     - run: make lint
 
+  "generate":
+    docker:
+    - image: golang:1.15
+    resource_class: small
+    steps:
+    - checkout
+    - run: make generate-clean
+    - run: make generate
+    - dirty-check
+
 workflows:
 
   "dlib":
     jobs:
     - "test"
     - "lint"
+    - "generate"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+#
+# Intro
+
 help:
 	@echo 'Usage:'
 	@echo '  make help'
@@ -5,6 +8,11 @@ help:
 	@echo '  make dlib.cov.html'
 	@echo '  make lint'
 .PHONY: help
+
+.SECONDARY:
+
+#
+# Test
 
 dlib.cov: test
 test:
@@ -14,11 +22,26 @@ test:
 %.cov.html: %.cov
 	go tool cover -html=$< -o=$@
 
-.circleci/%: .circleci/%.d/go.mod .circleci/%.d/pin.go
-	cd $(<D) && go build -o ../$(@F) $$(sed -En 's,^import "(.*)"$$,\1,p' pin.go)
+#
+# Generate
+
+generate-clean:
+	rm -f dlog/convenience.go
+.PHONY: generate-clean
+
+generate:
+	go generate ./...
+.PHONY: generate
+
+#
+# Lint
 
 lint: .circleci/golangci-lint
 	.circleci/golangci-lint run ./...
 .PHONY: lint
 
-.SECONDARY:
+#
+# Tools
+
+.circleci/%: .circleci/%.d/go.mod .circleci/%.d/pin.go
+	cd $(<D) && go build -o ../$(@F) $$(sed -En 's,^import "(.*)"$$,\1,p' pin.go)


### PR DESCRIPTION
I realized that the `generate.mk` rules for dlog didn't make the copy from ambassador.git to dlib.git, so do that now.