### PR TITLE
Improve documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,21 @@
 dlib is a set of small independent-but-complementary Context-oriented
 Go libraries.
 
-If each of the packages in dlib are independent, why are they lumped
-together in to dlib?  They share common design principles:
+For the most part, each library within dlib is independent, and has a
+a different problem statement.  If they are each independent, why are
+they lumped together in to dlib?  Because they share common design
+principles; dlib is lumped together so that the user can trust that
+these principles have been reasonably consistently applied, and can
+spend less time evaluating the library before deciding whether to use
+it.
+
+# Design principles
+
+The thing binding together the different packages within dlib are that
+they share common design principles.  The tagline is that they are
+"small independent-but-complementary Context-oriented" packages, and
+each one of those words (except "but") has a lot of meaning packed in
+to it, and states one of the design principles:
 
  - Packages should be small.
 
@@ -103,25 +116,60 @@ together in to dlib?  They share common design principles:
    has the prettiest don't need to affect the code that is written,
    except for one-time setup in the final application's `main()`.
 
- - Defaults should be useful.
+   When there is something that a package don't want to or can't take
+   as an argument, rather than making it a global variable or other
+   global state, it should be packed in to a Context.  Then, rather
+   than reading it out of a variable, the function making use of it
+   can read it out of the Context.  And that won't be a problem,
+   because everything that might want some kind of ambient state will
+   take a Context as an argument, right?  Perhaps it helps to think of
+   a Context as an explicit passing of the ambient environment that a
+   function is executing it.
 
-   The core of `dlog` doesn't actually do much of anything; it
-   delegates to a pluggable logging backend, but it uses a
-   `logrus`-based backend by default; few users will be upset by this
-   default logging with colorized output and timestamps.  Having
-   useful defaults is a backing-assumption for being Context-oriented.
-   If `dlog` didn't have a useful default logger, then using it
-   wouldn't be a no-brainer, using `dlog` would force the user of that
-   package to care about `dlog` and whether or not they'd taken care
-   to configure the logger ahead-of-time.
+   Contexts were added in Go 1.7, and turned out to be a paradigm
+   shift.  And it's often a long journey to actually agreeing that
+   Contexts are a good idea (personally, it took @LukeShu years to
+   come around).  The Official position is that everything new should
+   use Contexts, but because of years of historical pre-Context code,
+   and because of people who still haven't come around to Contexts, a
+   lot of things don't use Contexts.  So when we say
+   "Context-oriented", what we're saying is which side of history dlib
+   is on.
 
-   A zero `dgroup.GroupConfig{}` is useful without filling in any
-   settings; things that are on by default have a `DisableXXX` bool,
-   and things that are off by default have an `EnableXXX` bool.  The
-   most-common configuration will be empty, and the second-most-common
-   configuration will be the just the 1 item `EnableSignalHandling:
-   true` (which we can't make the default because it would be bad to
-   set it up multiple signal handler in the same program).
+   And through the organic history of what is now dlib, we've seen how
+   that one "Contexts are good" opinion has allowed our libraries to
+   sidestep having other more ornery opinions and sidestep other
+   tricky design decisions.
+
+    + Defaults should be useful.
+
+      A zero `dgroup.GroupConfig{}` is useful without filling in any
+      settings; things that are on by default have a `DisableXXX`
+      bool, and things that are off by default have an `EnableXXX`
+      bool.  The most-common configuration will be empty, and the
+      second-most-common configuration will be the just the 1 item
+      `EnableSignalHandling: true` (which we can't make the default
+      because it would be bad to set it up multiple signal handler in
+      the same program).
+
+      The above paragraph is a general statement of a cultural value
+      in the Go community; "have meaningful zero values".  However,
+      being Context-oriented promotes that from a guideline to an
+      imperative: if you are reading your data out of a Context (as
+      `dlog` does), then you can't rely on having packed the data in
+      to the Context ahead-of-time; you must gracefully handle the
+      case where you don't get a value out.
+
+      The core of `dlog` doesn't actually do much of anything; it
+      delegates to a pluggable logging backend, but it uses a
+      `logrus`-based backend by default; few users will be upset by
+      this default logging with colorized output and timestamps.
+      Having useful defaults is a backing-assumption for being
+      Context-oriented.  If `dlog` didn't have a useful default
+      logger, then using it wouldn't be a no-brainer, using `dlog`
+      would force the user of that package to care about `dlog` and
+      whether or not they'd taken care to configure the logger
+      ahead-of-time.
 
 In all, dlib is lumped together so that the user can trust that these
 principles have been reasonably consistently applied.  The user can

--- a/README.md
+++ b/README.md
@@ -176,3 +176,9 @@ principles have been reasonably consistently applied.  The user can
 pull in one package from dlib and trust that they won't have to worry
 about having to adjust their program to that package's opinions
 (except of course, for the opinion that you should use Contexts!).
+
+# Example
+
+Everything is complementary, and so if you drink the Kool-Aid and want
+to see how to use everything together, check out [the example in
+`example_test.go`](https://pkg.go.dev/github.com/datawire/dlib)

--- a/dhttp/server.go
+++ b/dhttp/server.go
@@ -47,8 +47,15 @@ import (
 	"github.com/datawire/dlib/dlog"
 )
 
+// connContextFn is just a convenience type alias because the type signature for concatConnContext
+// would be really hard to read without it.  It is just a name for the type of the struct members
+// ServerConfig.ConnContext and http.Server.ConnContext.
 type connContextFn func(ctx context.Context, c net.Conn) context.Context
 
+// concatConnContext takes a list of zero or more callback-functions that would each be suitable as
+// a value for ServerConfig.ConnContext (or http.Server.ConnContext), and concatenates them together
+// in to one callback-function.  The input callback-functions will be run in the order that they're
+// passed to concatConnContext.
 func concatConnContext(fns ...connContextFn) connContextFn {
 	return func(ctx context.Context, c net.Conn) context.Context {
 		for _, fn := range fns {
@@ -64,20 +71,42 @@ func concatConnContext(fns ...connContextFn) connContextFn {
 	}
 }
 
+// testHookContextKey is a hack so that some of the tests can hook in to the Handler internals a
+// bit, via serverhook_test.go.
 type testHookContextKey struct{}
 
 // ServerConfig is a mostly-drop-in replacement for net/http.Server.
 //
 // This is better than http.Server because:
 //
-//  - It natively supports "h2c" (HTTP/2 over cleartext)
+//  - It natively supports "h2c" (HTTP/2 over cleartext).
+//
 //  - Its "h2c" support is better than http.Server with golang.org/x/net/http2/h2c.NewHandler,
-//    because it properly shuts down idle h2c connections when server.Shutdown is called, rather
-//    than allowing h2c connections to sit around forever.
+//    because it properly shuts down idle h2c connections when shutdown is initiated, rather than
+//    allowing h2c connections to sit around forever.
+//
 //  - It uses Context cancellation as a simple and composable shutdown mechanism; supporting
 //    dcontext hard/soft contexts, rather than awkward relationship between the Shutdown and Close
 //    methods.
+//
+//    Rather than having to set up a tree of cleanup functions calling each other down through your
+//    program and dealing with having to call .Shutdown() and .Close() from another goroutine (and
+//    having to understand the relationship between .Shutdown() and .Close() and when to call each,
+//    which is a bigger task than you might think), the "(ListenAnd)?Serve(TLS)?" methods simply
+//    take a Context and perform cleanup when the Context becomes Done.  In order to differentiate
+//    between whether you want it to hard-shutdown or graceful-shutdown, you may use the dcontext
+//    hard/soft mechanism; if you don't use dcontext then it will be a hard-shutdown.
+//
 //  - When shutting down, it properly blocks when waiting for the workers of hijacked connections.
+//
+//    Hijacked connections are connections for which the .Handler said to the server "you know what,
+//    stop doing HTTP and let me use the raw TCP socket" (as when having negotiated an upgrade from
+//    HTTP/1 to WebSockets or from HTTP/1 to HTTP/2).  It is a design deficiency in net/http.Server
+//    that the net/http.Server totally just stops tracking connections when they get hijacked;
+//    failing to close them when you call net/http.Server.Close() and failing to wait for them when
+//    you call net/http.Server.Shutdown(); and unfortunately that design deficiency is locked-in to
+//    *http.Server because of backward compatibility promises.
+//
 //  - If you use dlog, you don't have to manually configure the logging for the server to do the
 //    right thing.
 //
@@ -104,7 +133,7 @@ type testHookContextKey struct{}
 //    code's work.
 //
 // Arguably-breaking changes from http.Server that to ServerConfig that I'd say are bugfixes, but
-// could conceivably[1] make someone's old code incorrect:
+// could conceivably[2] make someone's old code incorrect:
 //
 //  - *http.Server.ServeTLS won't close the Listener if .ServeTLS returns early during setup due to
 //    having been passed invalid cert or key files; ServerConfig.ServeTLS will always close the
@@ -114,12 +143,11 @@ type testHookContextKey struct{}
 // functions that take an *http.Server as an argument) is that it became increasingly clear that the
 // lifecycle of a running server is tied to the lifecycle of the *http.Server object, while we've
 // grown a standard "Context" lifecycle system that wants to tie the lifecycle to the function call,
-// Rather than to the object.  This divorce between the running-server lifecycle and the object is
-// embodied in the name of the type; when the lifecycle of the object was the lifecycle of the
-// server, the object *was* the server, so it was named *http.Server; now the lifecycle is divorced
-// from that, and the object is just configuration for the server, so it is named *ServerConfig.
+// rather than to the object.  This divorce between lifecycles is embodied in the name of the type;
+// when the lifecycle was tied to the object the type was named *http.Server.  Now the lifecycle is
+// divorced from that, and the object is just configuration, so the type is named *ServerConfig.
 //
-// [1]: https://xkcd.com/1172/
+// [2]: https://xkcd.com/1172/
 type ServerConfig struct {
 	// These fields mimic exactly mimic http.Server; see the documentation there.
 	Handler           http.Handler
@@ -271,7 +299,7 @@ func (sc *ServerConfig) serve(ctx context.Context, serveFn func(*http.Server) er
 	}
 
 	// At this point, everything managed by the http.Server has finished, but hijacked
-	// connections may still be going.  We don't want to forcfully kill them if we haven't
+	// connections may still be going.  We don't want to forcefully kill them if we haven't
 	// actually had a hard shutdown triggered yet.  So wait for that to happen.
 	workersDoneCh := make(chan struct{})
 	go func() {
@@ -287,7 +315,8 @@ func (sc *ServerConfig) serve(ctx context.Context, serveFn func(*http.Server) er
 	}
 
 	// Trigger the hard shutdown.  This is probably not nescessary in the <-workersDoneCh case,
-	// but let's do it in both cases, just to be safe.
+	// but let's do it in both cases, just to be safe (the "close" calls should be safe no-ops
+	// in the <-workersDoneCh case).
 	//
 	// If the hardCtx becomes Done before server shuts down, then server.Shutdown() simply
 	// returns early, without doing any more-aggressive shutdown logic.  So we really do need to
@@ -307,22 +336,34 @@ func (sc *ServerConfig) serve(ctx context.Context, serveFn func(*http.Server) er
 	return err
 }
 
-// Serve accepts incoming connection on the Listener ln, creating a new service goroutine for each.
-// The service goroutines read requests and call sc.Handler to reply to them.
+// Serve accepts incoming connections on the Listener ln, creating a new worker goroutine for each.
+// The worker goroutines read requests and call sc.Handler to reply to them.
+//
+// When the Context ctx becomes Done, Serve starts shutting down and prepares to return; it closes
+// the listener, closes idle connections, and either (1) waits for any active connections to finish,
+// or (2) forcefully closes any active connections.  When using a vanilla Context, it forcefully
+// closes the connections; when using a dcontext "soft" Context, it will wait for the connections
+// when the Context becomes soft-Done, and will forcefully close the connections when the Context
+// becomes hard-Done.
+//
+// If the Context becomes Done and Serve is able to return without having to forcefully close any
+// active connections, then nil is returned.  If Server encounters an error and must stop serving,
+// or if Serve had to forcefully close any active connections during shutdown, then an error is
+// returned.
 //
 // Serve always closes the Listener before returning.
 func (sc *ServerConfig) Serve(ctx context.Context, ln net.Listener) error {
 	return sc.serve(ctx, func(srv *http.Server) error { return srv.Serve(ln) })
 }
 
-// Serve accepts incoming connection on the Listener ln, creating a new service goroutine for each.
-// The service goroutines perform TLS setup, and then read requests and call sc.Handler to reply to
-// them.
+// ServeTLS is like Serve, except that the worker goroutines perform TLS setup on the connection
+// before going in to their read-loop.
 //
-// Files containing a certificate and matching private key for the server must be provided if
-// neither the Server's TLSConfig.Certificates nor TLSConfig.GetCertificate are populated.  If the
-// certificate is signed by a certificate authority, the certFile should be the concatenation of the
-// server's certificate, any intermediates, and the CA's certificate.
+// Filenames containing a certificate and matching private key for the server must be provided if
+// neither the ServerConfig's TLSConfig.Certificates nor TLSConfig.GetCertificate are populated.  If
+// the certificate is signed by a certificate authority, the certFile should be the concatenation of
+// the server's certificate, any intermediates, and the CA's certificate.  If TLSConfig.Certificates
+// are TLSConfig.GetCertificate are populated, then you may pass empty strings as the filenames.
 //
 // ServeTLS always closes the Listener before returning (this is slightly different than
 // *http.Server.ServeTLS, which does not close the Listener if returning early during setup due to

--- a/dhttp/server_hijacked.go
+++ b/dhttp/server_hijacked.go
@@ -10,19 +10,40 @@ import (
 type connContextKey struct{}
 
 // configureHijackTracking configures (mutates) an *http.Server to provide slightly better tracking
-// of Hijack()ed connections.  It returns a 'close' function that closes all active hijacked
-// connections (you should call this when you call server.Close), and a 'wait' function that blocks
-// until all of the workers have quit (you should call this when you call server.Shutdown).
+// of Hijack()ed connections.
+//
+// Hijack()ed connections are connections for which the http.Server.Handler said to the *http.Server
+// "you know what, stop doing HTTP and let me use the raw TCP socket" (as when having negotiated an
+// upgrade from HTTP/1 to WebSockets or from HTTP/1 to HTTP/2).  It is a design deficiency in
+// *http.Server that the *http.Server totally just stops tracking connections when they get
+// Hijack()ed; failing to close them when you call *http.Server.Close() and failing to wait for them
+// when you call *http.Server.Shutdown(); and unfortunately that design deficiency is locked-in to
+// *http.Server because of backward compatibility promises.
+//
+// So configureHijackTracking addresses that deficiency, and adds hooks in to the *http.Server in
+// order to do its own tracking of the Hijack()ed connections, and returns two functions that will
+// perform those two deficient operations for Hijack()ed connections.  It returns a 'close' function
+// that closes all active Hijack()ed connections (you should call this when you call server.Close),
+// and a 'wait' function that blocks until all of the workers have quit (you should call this
+// immediately after you call server.Shutdown).
 //
 // This wraps the server.Handler, so it should be called *after* setting up any Handler that might
-// hijack connections.
+// Hijack() connections.
 func configureHijackTracking(server *http.Server) (close func(), wait func()) {
 	var wg sync.WaitGroup
 
 	var mu sync.Mutex                            // protects 'hijackedConns'
 	hijackedConns := make(map[net.Conn]struct{}) // protected by 'mu'
+	closeHijacked := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for conn := range hijackedConns {
+			conn.Close()
+			delete(hijackedConns, conn)
+		}
+	}
 
-	// Make a note of it whenever a connection gets hijacked.
+	// Hook in to .ConnState in order to make a note of it whenever a connection gets hijacked.
 	origConnState := server.ConnState
 	server.ConnState = func(conn net.Conn, state http.ConnState) {
 		if origConnState != nil {
@@ -35,7 +56,8 @@ func configureHijackTracking(server *http.Server) (close func(), wait func()) {
 		}
 	}
 
-	// Pack the net.Conn in to the context, so that we can access it below.
+	// Hook in to .ConnContext in order to pack the net.Conn in to the Context, so that we can
+	// access it below.
 	server.ConnContext = concatConnContext(
 		func(ctx context.Context, c net.Conn) context.Context {
 			return context.WithValue(ctx, connContextKey{}, c)
@@ -43,9 +65,9 @@ func configureHijackTracking(server *http.Server) (close func(), wait func()) {
 		server.ConnContext,
 	)
 
-	// (1) Make a note of it whenever a hijacked connection's worker returns, so that we don't
-	// need to keep track of that connection forever. (2) Keep track of whether there are still
-	// outstanding workers.
+	// Hook in to .Handler in order to (1) make a note of it whenever a hijacked connection's
+	// worker returns, so that we don't need to keep track of that connection forever; and (2)
+	// keep track of whether there are still outstanding workers.
 	origHandler := server.Handler
 	if origHandler == nil {
 		origHandler = http.DefaultServeMux
@@ -62,14 +84,6 @@ func configureHijackTracking(server *http.Server) (close func(), wait func()) {
 		origHandler.ServeHTTP(w, r)
 	})
 
-	closeHijacked := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		for conn := range hijackedConns {
-			conn.Close()
-			delete(hijackedConns, conn)
-		}
-	}
-
+	// Return.
 	return closeHijacked, wg.Wait
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Module dlib is a collection of small independent-but-complementary Context-oriented packages.
+package dlib

--- a/dutil/http_server.go
+++ b/dutil/http_server.go
@@ -14,10 +14,13 @@ import (
 
 func serverConfig(server *http.Server) (*dhttp.ServerConfig, error) {
 	if server.BaseContext != nil {
+		// Ask the runtime what's calling us, in order to put the correct
+		// "(ListenAnd)?Serve(TLS)?" function name in the error message.  Those functions
+		// are the only thing that calls this function.
 		pc, _, _, _ := runtime.Caller(1)
-		qname := runtime.FuncForPC(pc).Name()
-		dot := strings.LastIndex(qname, ".")
-		name := qname[dot+1:]
+		qname := runtime.FuncForPC(pc).Name() // Returns "domain.tld/pkgpath.Function".
+		dot := strings.LastIndex(qname, ".")  // Find the dot separating the pkg from the func.
+		name := qname[dot+1:]                 // Split on that dot.
 		return nil, errors.Errorf("it is invalid to call %s with the Server.BaseContext set", name)
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,181 @@
+package dlib_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/datawire/dlib/dcontext"
+	"github.com/datawire/dlib/derror"
+	"github.com/datawire/dlib/dexec"
+	"github.com/datawire/dlib/dgroup"
+	"github.com/datawire/dlib/dhttp"
+	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/dlib/dtime"
+)
+
+// This is an example main() program entry-point that shows how all the pieces of dlib can fit
+// together and complement each other.
+func main() {
+	// Start with the background Context as the root Context.
+	ctx := context.Background()
+
+	// The default backend for dlog is pretty good, but for the sake of example, let's customize
+	// it a bit.
+	ctx = dlog.WithLogger(ctx, func() dlog.Logger {
+		// Let's have the backend be logrus.  The default backend is already logrus, but
+		// ours will be customized.
+		logrusLogger := logrus.New()
+		// The dlog default is InfoLevel; let's crank it up to DebugLevel.
+		logrusLogger.Level = logrus.DebugLevel
+		// Now turn that in to a dlog.Logger backend, so we can pass it to dlog.WithLogger.
+		return dlog.WrapLogrus(logrusLogger)
+	}())
+
+	// We're going to be doing several tasks in parallel, so we'll use "dgroup" to manage our
+	// group of goroutines.
+	grp := dgroup.NewGroup(ctx, dgroup.GroupConfig{
+		// Enable signal handling for graceful shutdown.  The user can stop the program by
+		// sending it SIGINT with Ctrl-C, and that will start a graceful shutdown.  If that
+		// graceful shutdown takes too long, and the user hits Ctrl-C again, then it will
+		// start a not-so-graceful shutdown.
+		//
+		// This shutdown will be signaled to the worker goroutines through the Context that
+		// gets passed to them.  The mechanism by which the Context signals both graceful
+		// and not-so-graceful shutdown is what "dcontext" is for.
+		EnableSignalHandling: true,
+	})
+
+	// One of those tasks will be running an HTTP server.
+	grp.Go("http", func(ctx context.Context) error {
+		// We'll be using a *dhttp.ServerConfig instead of an *http.Server, but it works
+		// very similarly to *http.Server, everything else in the stdlib net/http package is
+		// still valid; we'll still be using plain-old http.ResponseWriter and *http.Request
+		// and http.HandlerFunc.
+		cfg := &dhttp.ServerConfig{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				dlog.Debugln(r.Context(), "handling HTTP request")
+				_, _ = w.Write([]byte("Hello, world!\n"))
+			}),
+		}
+		// ListenAndServe will gracefully shut down according to ctx; we don't need to worry
+		// about separately calling .Shutdown() or .Close() like we would for *http.Server
+		// (those methods don't even exist on dhttp.ServerConfig).  During a graceful
+		// shutdown, it will stop listening and close idle connections, but will wait on any
+		// active connections; during a not-so-graceful shutdown it will forcefully close
+		// any active connections.
+		//
+		// If the server itself needs to log anything, it will use dlog according to ctx.
+		// The Request.Context() passed to the Handler function will inherit from ctx, and
+		// so the Handler will also log according to ctx.
+		//
+		// And, on the end-user-facing side of things, this supports HTTP/2, where
+		// *http.Server.ListenAndServe wouldn't.
+		return cfg.ListenAndServe(ctx, ":8080")
+	})
+
+	// Another task will be running external host operating system commands.
+	grp.Go("exec", func(ctx context.Context) error {
+		// dexec is *almost* a drop-in replacement for os/exec; the only breaking change is
+		// that .Command() doesn't exist anymore, you *must* use the .CommandContext()
+		// variant.
+		//
+		// There are two nice things using dexec instead of os/exec this gets us.
+		//
+		// Firstly: dexec logs everything read from or written to the command's stdin,
+		// stdout, and stderr; logging with dlog according to ctx.  Logging of one of any of
+		// these can be opted-out of; see the dexec documentation.
+		//
+		// Secondly: When the Context signals a shutdown, os/exec responds by stopping the
+		// command by sending it the SIGKILL signal.  Now, "sending the SIGKILL signal" is a
+		// bit of a misleading phrase, because SIGKILL is never actually sent to the
+		// process, it instead tells the operating system to just stop giving the process
+		// any CPU time; the process is just abruptly dead.  dexec gives the process a
+		// chance to gracefully shutdown by sending it SIGINT for a graceful shutdown, and
+		// only sending it SIGKILL for a not-so-graceful shutdown.
+		cmd := dexec.CommandContext(ctx, "some", "long-running", "command", "--keep-going")
+		return cmd.Run()
+	})
+
+	// Another task will be running our own code.
+	grp.Go("code", func(ctx context.Context) error {
+		dataSourceCh := newDataSource(ctx)
+	theloop:
+		for {
+			select {
+			case <-ctx.Done():
+				// The channel <-ctx.Done() gets closed when either a graceful or
+				// not-so-graceful shutdown is triggerd.
+				//
+				// So, when the Context signals us to shut down, we'll break out of
+				// this `for` loop.
+				break theloop
+				// ... but until then, read from dataSourceCh, and process the data
+				// from it:
+			case dat := <-dataSourceCh:
+				// The doWorkOnData example function might be a little buggy and
+				// might panic().  We don't want that to cause us to stop processing
+				// more data early, so we'll use derror to catch any panics and turn
+				// them in to useful errors.
+				func() {
+					defer func() {
+						if err := derror.PanicToError(recover()); err != nil {
+							// Thanks to PanicToError, err has the panic
+							// stacktrace attached to it, which we can
+							// show using the "+" modifier to "%v".
+							dlog.Errorf(ctx, "doWorkOnData crashed: %+v", err)
+						}
+					}()
+					doWorkOnData(ctx, dat)
+				}()
+				// We want ensure we wait at least 10 seconds between each time we
+				// call DoWorkOnData, but we also don't want to stall a graceful
+				// shutdown by 10 seconds, so we'll use dtime.SleepWithContext
+				// instead of stdlib time.Sleep.  (We also don't use stdlib
+				// time.After, because that would leak channels; we don't want
+				// memory leaks!)
+				dtime.SleepWithContext(ctx, 10*time.Second)
+			}
+		}
+
+		// OK, if we're here it's because <-ctx.Done() and we broke out of the `for` loop.
+		//
+		// We have some cleanup we'd like to do for a graceful shutdown, but we should bail
+		// early on that work if a not-so-graceful shutdown is triggered.  If <-ctx.Done()
+		// is already closed because of a graceful shutdown, how do we detect when a
+		// not-so-graceful shutdown is triggered?
+		//
+		// Well, ctx is a "soft" Context; signaling a "soft" (graceful) shutdown.  We'll use
+		// dcontext.HardContext to get the "hard" Context from it, which signals just a
+		// "hard" (not-so-graceful) shutdown.
+		ctx = dcontext.HardContext(ctx)
+		return gracefulCleanup(ctx)
+	})
+
+	if err := grp.Wait(); err != nil {
+		dlog.Errorf(ctx, "finished with error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func newDataSource(_ context.Context) <-chan struct{} {
+	// Not actually implemented for this example.
+	return nil
+}
+
+func doWorkOnData(_ context.Context, _ struct{}) {
+	// Not actually implemented for this example.
+}
+
+func gracefulCleanup(_ context.Context) error {
+	// Not actually implemented for this example.
+	return nil
+}
+
+func Example_main() {
+	// An "Example_XXX" function is needed to get this example to show up in the godoc.
+	main()
+}


### PR DESCRIPTION
1. Improve the dhttp documentation and comments based on feedback from @kflynn on https://github.com/datawire/dlib/pull/6 .
2. Add a "This is how it all fits together" example, based on the suggestion from @rhs.
3. Talk about why dlib exists a bit more upfront, based on conversation with @rdl (hopefully this obviates https://github.com/datawire/dlib/pull/7 ?)