### PR TITLE
CI: Don't include *_bundle.go files in the code-coverage tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,9 @@ jobs:
         command: |
           set -e
           if test -e dlib.cov; then
+            sed '/_bundle\.go:/d' <dlib.cov >dlib-coveralls.cov
             make .circleci/goveralls
-            .circleci/goveralls -coverprofile=dlib.cov -service=circle-ci -repotoken=$COVERALLS_TOKEN
+            .circleci/goveralls -coverprofile=dlib-coveralls.cov -service=circle-ci -repotoken=$COVERALLS_TOKEN
           fi
         when: always
 


### PR DESCRIPTION
This is really two things:
- I adjusted CircleCI to only run on PRs, since it seemed coveralls.io was getting confused and letting CI pass because the branch CI didn't compare to master; so it didn't realize that coverage went down.  So I'm looking specifically for a "coverage increased" CI status to verify that it's comparing things correctly now.
- Don't include `*_bundle.go` (vendored) files in the code-coverage regression test.  They artificially lower the number.