### PR TITLE
dexec: Improve log output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 
 dlib.cov: test
 test:
-	go test -coverprofile=dlib.cov -race ./...
+	go test -coverprofile=dlib.cov -coverpkg=./... -race ./...
 .PHONY: test
 
 %.cov.html: %.cov

--- a/dexec/cmd.go
+++ b/dexec/cmd.go
@@ -128,6 +128,8 @@ func (c *Cmd) logiofn(stream string) func(error, []byte) {
 		if err != nil {
 			ctx = dlog.WithField(ctx, "dexec.err", err)
 		}
+		// We don't have an additional message to log; all of the info that we want to log
+		// is provided via dlog.WithField.
 		dlog.Print(ctx)
 	}
 }

--- a/dexec/cmd.go
+++ b/dexec/cmd.go
@@ -14,9 +14,9 @@
 // CommandContext by calling
 // github.com/datawire/dlib/dlog.WithLogger.
 //
-// A Cmd logs when it starts, its exit status, and if they aren't an
-// *os.File, logs everything read from or written to .Stdin, .Stdout,
-// and .Stderr.  If one of those is an *os.File (as it is following a
+// A Cmd logs when it starts, its exit status, and everything read
+// from or written to .Stdin, .Stdout, and .Stderr if they aren't an
+// *os.File.  If one of those is an *os.File (as it is following a
 // call to .StdinPipe, .StdoutPipe, or .StderrPipe), then that stream
 // won't be logged (but it will print a message at process-start
 // noting that it isn't being logged).
@@ -28,13 +28,13 @@
 //     cmd.Stdin = os.Stdin
 //     err := cmd.Run()
 //
-// will log the lines
+// will log the lines (assuming the default dlog configuration):
 //
-//     [pid:24272] started command []string{"printf", "%s\n", "foo bar", "baz"}
-//     [pid:24272] stdin  < not logging input read from file /dev/stdin
-//     [pid:24272] stdout+stderr > "foo bar\n"
-//     [pid:24272] stdout+stderr > "baz\n"
-//     [pid:24272] finished successfully: exit status 0
+//     time="2021-05-18T17:18:35-06:00" level=info dexec.pid=24272 msg="started command [\"printf\" \"%s\\n\" \"foo bar\" \"baz\"]"
+//     time="2021-05-18T17:18:35-06:00" level=info dexec.pid=24272 dexec.stream=stdin msg="not logging input read from file \"/dev/stdin\""
+//     time="2021-05-18T17:18:35-06:00" level=info dexec.pid=24272 dexec.stream=stdout+stderr dexec.data="foo bar\n"
+//     time="2021-05-18T17:18:35-06:00" level=info dexec.pid=24272 dexec.stream=stdout+stderr dexec.data="baz\n"
+//     time="2021-05-18T17:18:35-06:00" level=info dexec.pid=24272 msg="finished successfully: exit status 0"
 //
 // If you would like a "pipe" to be logged, use an io.Pipe instead of
 // calling .StdinPipe, .StdoutPipe, or .StderrPipe.
@@ -108,8 +108,8 @@ func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 	return ret
 }
 
-func (c *Cmd) logiofn(prefix string) func(string) {
-	return func(msg string) {
+func (c *Cmd) logiofn(stream string) func(error, []byte) {
+	return func(err error, msg []byte) {
 		if c.DisableLogging {
 			return
 		}
@@ -120,7 +120,15 @@ func (c *Cmd) logiofn(prefix string) func(string) {
 		if c.Process != nil {
 			pid = c.Process.Pid
 		}
-		dlog.Printf(c.ctx, "[pid:%v] %s %s", pid, prefix, msg)
+		ctx := dlog.WithField(c.ctx, "dexec.pid", pid)
+		ctx = dlog.WithField(ctx, "dexec.stream", stream)
+		if msg != nil {
+			ctx = dlog.WithField(ctx, "dexec.data", string(msg))
+		}
+		if err != nil {
+			ctx = dlog.WithField(ctx, "dexec.err", err)
+		}
+		dlog.Print(ctx)
 	}
 }
 
@@ -128,27 +136,28 @@ func (c *Cmd) logiofn(prefix string) func(string) {
 //
 // See the os/exec.Cmd.Start documenaton for more information.
 func (c *Cmd) Start() error {
-	c.Stdin = fixupReader(c.Stdin, c.logiofn("stdin  <"))
+	c.Stdin = fixupReader(c.Stdin, c.logiofn("stdin"))
 	if interfaceEqual(c.Stdout, c.Stderr) {
-		c.Stdout = fixupWriter(c.Stdout, c.logiofn("stdout+stderr >"))
+		c.Stdout = fixupWriter(c.Stdout, c.logiofn("stdout+stderr"))
 		c.Stderr = c.Stdout
 	} else {
-		c.Stdout = fixupWriter(c.Stdout, c.logiofn("stdout >"))
-		c.Stderr = fixupWriter(c.Stderr, c.logiofn("stderr >"))
+		c.Stdout = fixupWriter(c.Stdout, c.logiofn("stdout"))
+		c.Stderr = fixupWriter(c.Stderr, c.logiofn("stderr"))
 	}
 
 	err := c.Cmd.Start()
 	if err == nil {
 		if !c.DisableLogging {
-			dlog.Printf(c.ctx, "[pid:%v] started command %#v", c.Process.Pid, c.Args)
+			ctx := dlog.WithField(c.ctx, "dexec.pid", c.Process.Pid)
+			dlog.Printf(ctx, "started command %q", c.Args)
 			if stdin, isFile := c.Stdin.(*os.File); isFile {
-				dlog.Printf(c.ctx, "[pid:%v] stdin  < not logging input read from file %s", c.Process.Pid, stdin.Name())
+				dlog.Printf(dlog.WithField(ctx, "dexec.stream", "stdin"), "not logging input read from file %q", stdin.Name())
 			}
 			if stdout, isFile := c.Stdout.(*os.File); isFile {
-				dlog.Printf(c.ctx, "[pid:%v] stdout > not logging output written to file %s", c.Process.Pid, stdout.Name())
+				dlog.Printf(dlog.WithField(ctx, "dexec.stream", "stdout"), "not logging output written to file %q", stdout.Name())
 			}
 			if stderr, isFile := c.Stderr.(*os.File); isFile {
-				dlog.Printf(c.ctx, "[pid:%v] stderr > not logging output written to file %s", c.Process.Pid, stderr.Name())
+				dlog.Printf(dlog.WithField(ctx, "dexec.stream", "stderr"), "not logging output written to file %q", stderr.Name())
 			}
 		}
 		if c.ctx != dcontext.HardContext(c.ctx) {
@@ -186,10 +195,11 @@ func (c *Cmd) Wait() error {
 	}
 
 	if !c.DisableLogging {
+		ctx := dlog.WithField(c.ctx, "dexec.pid", pid)
 		if err == nil {
-			dlog.Printf(c.ctx, "[pid:%v] finished successfully: %v", pid, c.ProcessState)
+			dlog.Printf(ctx, "finished successfully: %v", c.ProcessState)
 		} else {
-			dlog.Printf(c.ctx, "[pid:%v] finished with error: %v", pid, err)
+			dlog.Printf(ctx, "finished with error: %v", err)
 		}
 	}
 

--- a/dexec/reader.go
+++ b/dexec/reader.go
@@ -2,13 +2,11 @@ package dexec
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
-	"unicode/utf8"
 )
 
-func fixupReader(o io.Reader, log func(string)) io.Reader {
+func fixupReader(o io.Reader, log func(error, []byte)) io.Reader {
 	if o == nil {
 		o = nilReader{}
 	}
@@ -27,7 +25,7 @@ type nilReader struct{}
 func (nilReader) Read(_ []byte) (int, error) { return 0, io.EOF }
 
 type loggingReader struct {
-	log    func(string)
+	log    func(error, []byte)
 	reader io.Reader
 }
 
@@ -45,30 +43,11 @@ func (l *loggingReader) Read(p []byte) (n int, err error) {
 			line = toLog[:nl+1]
 			toLog = toLog[nl+1:]
 		}
-		if utf8.Valid(line) {
-			if utf8.RuneCount(line) > 80 {
-				truncated := line
-				for utf8.RuneCount(truncated) > 80 {
-					_, size := utf8.DecodeLastRune(truncated)
-					truncated = truncated[:len(truncated)-size]
-				}
-				l.log(fmt.Sprintf("%q… (%d runes truncated)",
-					truncated,
-					utf8.RuneCount(line)-utf8.RuneCount(truncated)))
-			} else {
-				l.log(fmt.Sprintf("%q", line))
-			}
-		} else {
-			l.log(fmt.Sprintf("[...%d bytes of binary data...]", len(line)))
-		}
+		l.log(nil, line)
 	}
 
 	if err != nil {
-		if err == io.EOF {
-			l.log("EOF")
-		} else {
-			l.log(fmt.Sprintf("error = %v", err))
-		}
+		l.log(err, nil)
 	}
 
 	return n, err

--- a/dexec/supervisor_test.go
+++ b/dexec/supervisor_test.go
@@ -62,6 +62,7 @@ func TestCommandRunLogging(t *testing.T) {
 			Out: logoutput,
 			Formatter: &logrus.TextFormatter{
 				DisableTimestamp: true,
+				SortingFunc:      dlog.DefaultFieldSort,
 			},
 			Hooks: make(logrus.LevelHooks),
 			Level: logrus.DebugLevel,
@@ -77,15 +78,18 @@ func TestCommandRunLogging(t *testing.T) {
 
 	//nolint:lll
 	expectedLines := []string{
-		`level=info msg="[pid:XXPIDXX] started command []string{\"bash\", \"-c\", \"cat; for i in $(seq 1 3); do echo $i; sleep 0.2; done\"}"`,
-		`level=info msg="[pid:XXPIDXX] stdin  < EOF"`,
-		`level=info msg="[pid:XXPIDXX] stdout+stderr > \"1\\n\""`,
-		`level=info msg="[pid:XXPIDXX] stdout+stderr > \"2\\n\""`,
-		`level=info msg="[pid:XXPIDXX] stdout+stderr > \"3\\n\""`,
-		`level=info msg="[pid:XXPIDXX] finished successfully: exit status 0"`,
+		`level=info dexec.pid=XXPIDXX msg="started command [\"bash\" \"-c\" \"cat; for i in $(seq 1 3); do echo $i; sleep 0.2; done\"]"`,
+		`level=info dexec.pid=XXPIDXX dexec.stream=stdin dexec.err=EOF`,
+		`level=info dexec.pid=XXPIDXX dexec.stream=stdout+stderr dexec.data="1\n"`,
+		`level=info dexec.pid=XXPIDXX dexec.stream=stdout+stderr dexec.data="2\n"`,
+		`level=info dexec.pid=XXPIDXX dexec.stream=stdout+stderr dexec.data="3\n"`,
+		`level=info dexec.pid=XXPIDXX msg="finished successfully: exit status 0"`,
 		``,
 	}
-	receivedLines := strings.Split(regexp.MustCompile("pid:[0-9]+").ReplaceAllString(logoutput.String(), "pid:XXPIDXX"), "\n") //nolint:lll
+	receivedLines := strings.Split(
+		regexp.MustCompile("dexec.pid=[0-9]+").
+			ReplaceAllString(logoutput.String(), "dexec.pid=XXPIDXX"),
+		"\n")
 	if len(receivedLines) != len(expectedLines) {
 		t.Log("log output didn't have the correct number of lines:")
 		for i, line := range expectedLines {

--- a/dexec/writer.go
+++ b/dexec/writer.go
@@ -2,13 +2,11 @@ package dexec
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
-	"unicode/utf8"
 )
 
-func fixupWriter(o io.Writer, log func(string)) io.Writer {
+func fixupWriter(o io.Writer, log func(error, []byte)) io.Writer {
 	if o == nil {
 		o = nilWriter{}
 	}
@@ -27,7 +25,7 @@ type nilWriter struct{}
 func (nilWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 type loggingWriter struct {
-	log    func(string)
+	log    func(error, []byte)
 	writer io.Writer
 }
 
@@ -45,30 +43,11 @@ func (l *loggingWriter) Write(p []byte) (n int, err error) {
 			line = toLog[:nl+1]
 			toLog = toLog[nl+1:]
 		}
-		if utf8.Valid(line) {
-			if utf8.RuneCount(line) > 80 {
-				truncated := line
-				for utf8.RuneCount(truncated) > 80 {
-					_, size := utf8.DecodeLastRune(truncated)
-					truncated = truncated[:len(truncated)-size]
-				}
-				l.log(fmt.Sprintf("%q… (%d runes truncated)",
-					truncated,
-					utf8.RuneCount(line)-utf8.RuneCount(truncated)))
-			} else {
-				l.log(fmt.Sprintf("%q", line))
-			}
-		} else {
-			l.log(fmt.Sprintf("[...%d bytes of binary data...]", len(line)))
-		}
+		l.log(nil, line)
 	}
 
 	if err != nil {
-		if err == io.EOF {
-			l.log("EOF")
-		} else {
-			l.log(fmt.Sprintf("error = %v", err))
-		}
+		l.log(err, nil)
 	}
 
 	return n, err

--- a/dlog/context.go
+++ b/dlog/context.go
@@ -54,7 +54,7 @@ func WithField(ctx context.Context, key string, value interface{}) context.Conte
 // StdLogger returns a stdlib *log.Logger that uses the Logger
 // associated with ctx and logs at the specified loglevel.
 //
-// Avoid using this functions if at all possible; prefer to use the
+// Avoid using this function if at all possible; prefer to use the
 // {Trace,Debug,Info,Print,Warn,Error}{f,ln,}() functions.  You should
 // only use this for working with external libraries that demand a
 // stdlib *log.Logger.


### PR DESCRIPTION
I was reviewing a Telepresence PR from Thomas, and wanted to play with one of the tests to better understand what the code was doing, and was being bitten by dexec truncating the log output.  So I modified it to be more dlog-native!

By default it's a touch verbose, but because it's oriented around structured logging now, you can provide your own logrus.Formatter to make it pretty according to your application's needs.