### PR TITLE
dcontext: Add a WithoutCancel function for non-timed-out cleanup

### DIFF
--- a/dcontext/debug_test.go
+++ b/dcontext/debug_test.go
@@ -12,17 +12,39 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	baseStr := fmt.Sprint(ctx)
-	ctx = dcontext.WithSoftness(ctx)
-
-	softStr := fmt.Sprint(ctx)
-	hardStr := fmt.Sprint(dcontext.HardContext(ctx))
-
-	assert.Truef(t, strings.HasPrefix(softStr, baseStr+"."),
-		"Soft Context string does not start with %q: %q", baseStr+".", softStr)
-	assert.Equal(t,
-		softStr+".HardContext",
-		hardStr)
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	testcases := []struct {
+		Name   string
+		SetCtx func()
+		Suffix string
+	}{
+		{
+			Name: "WithCancel",
+			SetCtx: func() {
+				ctx, cancel = context.WithCancel(ctx)
+				t.Cleanup(cancel)
+			},
+			Suffix: "WithCancel",
+		},
+		{"WithSoftness", func() { ctx = dcontext.WithSoftness(ctx) }, ""},
+		{"HardContext", func() { ctx = dcontext.HardContext(ctx) }, "HardContext"},
+		{"WithoutCancel", func() { ctx = dcontext.WithoutCancel(ctx) }, "WithoutCancel"},
+	}
+	t.Log(fmt.Sprint(ctx))
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			before := fmt.Sprint(ctx)
+			tc.SetCtx()
+			after := fmt.Sprint(ctx)
+			t.Log(after)
+			if tc.Suffix == "" {
+				assert.Truef(t, strings.HasPrefix(after, before+"."),
+					"%s string does not start with %q: %q", tc.Name, before+".", after)
+			} else {
+				assert.Equal(t, before+"."+tc.Suffix, after)
+			}
+		})
+	}
 }

--- a/dcontext/without_cancel.go
+++ b/dcontext/without_cancel.go
@@ -1,0 +1,23 @@
+package dcontext
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type withoutCancel struct {
+	context.Context
+}
+
+func (withoutCancel) Deadline() (deadline time.Time, ok bool) { return }
+func (withoutCancel) Done() <-chan struct{}                   { return nil }
+func (withoutCancel) Err() error                              { return nil }
+func (c withoutCancel) String() string                        { return fmt.Sprintf("%v.WithoutCancel", c.Context) }
+
+// WithoutCancel returns a copy of parent that inherits only values and not
+// deadlines/cancellation/errors.  This is useful for implementing non-timed-out
+// tasks during cleanup.
+func WithoutCancel(parent context.Context) context.Context {
+	return withoutCancel{parent}
+}

--- a/dcontext/without_cancel_test.go
+++ b/dcontext/without_cancel_test.go
@@ -25,8 +25,7 @@ func TestWithoutCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 0)
 	defer cancel()
 	ctx = context.WithValue(ctx, ctxKey{}, "foo")
-	for ctx.Err() == nil {
-	}
+	<-ctx.Done()
 
 	// sanity check
 	deadline, ok := ctx.Deadline()

--- a/dcontext/without_cancel_test.go
+++ b/dcontext/without_cancel_test.go
@@ -1,0 +1,48 @@
+package dcontext_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/datawire/dlib/dcontext"
+)
+
+func TestWithoutCancel(t *testing.T) {
+	isClosed := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}
+	type ctxKey struct{}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 0)
+	defer cancel()
+	ctx = context.WithValue(ctx, ctxKey{}, "foo")
+	for ctx.Err() == nil {
+	}
+
+	// sanity check
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok)
+	assert.True(t, deadline.Before(time.Now()))
+	assert.True(t, isClosed(ctx.Done()))
+	assert.Error(t, ctx.Err())
+	assert.Equal(t, "foo", ctx.Value(ctxKey{}))
+
+	ctx = dcontext.WithoutCancel(ctx)
+
+	// the actual meaningful check
+	deadline, ok = ctx.Deadline()
+	assert.False(t, ok)
+	assert.True(t, deadline.IsZero())
+	assert.False(t, isClosed(ctx.Done()))
+	assert.NoError(t, ctx.Err())
+	assert.Equal(t, "foo", ctx.Value(ctxKey{}))
+}


### PR DESCRIPTION
The idea+implementation is borrowed from Telepresence.  The tests are new.

A long time ago I had a conversation with Rafael Schloming about "what
about non-timed-out cleanup?" in the context of dgroup.

Well, much later, it turned out that Telepresence's answer to that was
withoutCancel{}.  So let's put that answer into dlib.