### PR TITLE
Windows support (Test on more platforms)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  windows: circleci/windows@2.4.0
+
 commands:
 
   "dirty-check":
@@ -21,9 +24,34 @@ commands:
                exit 1
             fi
 
+  "install-go":
+    parameters:
+      version:
+        type: string
+        default: "1.15"
+    steps:
+      - run:
+          name: "Install Go << parameters.version >>"
+          command: |
+            set -x
+            if [[ $OS == Windows_NT ]]; then
+              curl https://dl.google.com/go/go<< parameters.version >>.windows-amd64.zip -o /tmp/go.zip
+              mv /c/go /c/go-112
+              unzip -q /tmp/go.zip -d /c/
+            else
+              curl https://dl.google.com/go/go<< parameters.version >>.$(uname -s | tr A-Z a-z)-amd64.tar.gz -o /tmp/go.tar.gz
+              tar -C /tmp -xzf /tmp/go.tar.gz
+              echo 'export PATH=/tmp/go/bin:$PATH' >> "$BASH_ENV"
+              if [ -z "$(/tmp/go/bin/go env GOPROXY)" ]; then
+                echo 'export GOPROXY=https://proxy.golang.org' >> "$BASH_ENV"
+              fi
+              . "$BASH_ENV"
+            fi
+            go version
+
 jobs:
 
-  "test":
+  "test-linux":
     docker:
     - image: golang:1.15
     resource_class: small
@@ -39,6 +67,23 @@ jobs:
             .circleci/goveralls -coverprofile=dlib.cov -service=circle-ci -repotoken=$COVERALLS_TOKEN
           fi
         when: always
+
+  "test-darwin":
+    macos:
+      xcode: "12.4.0"
+    steps:
+    - install-go
+    - checkout
+    - run: make test
+
+  "test-windows":
+    executor:
+      name: windows/default
+      shell: bash.exe
+    steps:
+    - install-go
+    - checkout
+    - run: go test -race ./...
 
   "lint":
     docker:
@@ -62,6 +107,8 @@ workflows:
 
   "dlib":
     jobs:
-    - "test"
+    - "test-linux"
+    - "test-darwin"
+    - "test-windows"
     - "lint"
     - "generate"

--- a/dcontext/without_cancel_test.go
+++ b/dcontext/without_cancel_test.go
@@ -2,6 +2,7 @@ package dcontext_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -30,7 +31,14 @@ func TestWithoutCancel(t *testing.T) {
 	// sanity check
 	deadline, ok := ctx.Deadline()
 	assert.True(t, ok)
-	assert.True(t, deadline.Before(time.Now()))
+	switch runtime.GOOS {
+	case "windows":
+		// The Windows clock has low resolution, we might get the same
+		// time again.
+		assert.True(t, !deadline.After(time.Now()))
+	default:
+		assert.True(t, deadline.Before(time.Now()))
+	}
 	assert.True(t, isClosed(ctx.Done()))
 	assert.Error(t, ctx.Err())
 	assert.Equal(t, "foo", ctx.Value(ctxKey{}))

--- a/dexec/cmd_windows.go
+++ b/dexec/cmd_windows.go
@@ -1,0 +1,11 @@
+package dexec
+
+import (
+	"syscall"
+)
+
+func init() {
+	sysProcAttrForNewGroup = syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/dexec/logging_test.go
+++ b/dexec/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"text/template"
@@ -37,6 +38,15 @@ func newCapturingContext(tb testing.TB, w io.Writer) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	tb.Cleanup(cancel)
 	return ctx
+}
+
+// quote a string 1.5 times (quote it, then escape everything again but don't wrap it in quote
+// characters).
+func quote15(s string) string {
+	s = strconv.Quote(s)
+	s = strconv.Quote(s)
+	s = s[1 : len(s)-1]
+	return s
 }
 
 func TestOutputErrors(t *testing.T) {
@@ -125,7 +135,7 @@ func TestOutputErrors(t *testing.T) {
 	}
 
 	tmpl, err := template.New("expected.log.txt").Parse(`` +
-		`level=info msg="started command [\"` + os.Args[0] + `\" \"-test.run=TestLoggingHelperProcess\"]" dexec.pid={{ .PID }}` + "\n" +
+		`level=info msg="started command [` + quote15(os.Args[0]) + ` \"-test.run=TestLoggingHelperProcess\"]" dexec.pid={{ .PID }}` + "\n" +
 		`level=info dexec.err=EOF dexec.pid={{ .PID }} dexec.stream=stdin` + "\n" +
 		`level=info dexec.data="this is stdout\n" dexec.pid={{ .PID }} dexec.stream={{ .Stream }}` + "\n" +
 		`level=info msg="finished successfully: exit status 0" dexec.pid={{ .PID }}` + "\n" +
@@ -175,7 +185,7 @@ func TestLogging(t *testing.T) {
 		"default": {
 			InputStdout: &strings.Builder{},
 			ExpectedOutput: `` +
-				`level=info msg="started command [\"` + os.Args[0] + `\" \"-test.run=TestLoggingHelperProcess\"]" dexec.pid={{ .PID }}` + "\n" +
+				`level=info msg="started command [` + quote15(os.Args[0]) + ` \"-test.run=TestLoggingHelperProcess\"]" dexec.pid={{ .PID }}` + "\n" +
 				`level=info dexec.err=EOF dexec.pid={{ .PID }} dexec.stream=stdin` + "\n" +
 				`level=info dexec.data="this is stdout\n" dexec.pid={{ .PID }} dexec.stream=stdout` + "\n" +
 				`level=info msg="finished successfully: exit status 0" dexec.pid={{ .PID }}` + "\n",

--- a/dgroup/example_other_test.go
+++ b/dgroup/example_other_test.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package dgroup_test
+
+func ensureProcessGroup() (keepGoing bool) {
+	return true
+}

--- a/dgroup/example_windows_test.go
+++ b/dgroup/example_windows_test.go
@@ -1,0 +1,72 @@
+package dgroup_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func ensureProcessGroup() (keepGoing bool) {
+	if os.Getenv("GO_IN_OWN_PROCESS_GROUP") == "1" {
+		return true
+	}
+
+	pc, _, _, _ := runtime.Caller(1)
+	qname := runtime.FuncForPC(pc).Name() // Returns "domain.tld/pkgpath.Function".
+	dot := strings.LastIndex(qname, ".")  // Find the dot separating the pkg from the func.
+	name := qname[dot+1:]                 // Split on that dot.
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestExampleHelper", "--", name)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"GO_IN_OWN_PROCESS_GROUP=1")
+
+	if err := cmd.Run(); err != nil {
+		fmt.Println("switch process group:", err)
+	}
+	return false
+}
+
+func TestExampleHelper(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	subcommands := map[string]func(){
+		"Example_signalHandling1": Example_signalHandling1,
+		"Example_signalHandling2": Example_signalHandling2,
+		"Example_signalHandling3": Example_signalHandling3,
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	subcommand, ok := subcommands[args[0]]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Unknown command %q\n", args[0])
+		os.Exit(2)
+	}
+
+	subcommand()
+}

--- a/dtime/sleepwithcontext_test.go
+++ b/dtime/sleepwithcontext_test.go
@@ -3,6 +3,7 @@ package dtime
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -57,8 +58,15 @@ func TestSleep(t *testing.T) {
 			start := time.Now()
 			SleepWithContext(ctx, tcinfo.Arg)
 			actual := time.Since(start)
-			assertDurationEq(t, tcinfo.Expected, actual,
-				time.Second/100)
+
+			slop := 10 * time.Millisecond
+			switch  runtime.GOOS {
+			case "darwin":
+				slop *= 15 // Perhaps just CircleCI being bad, not darwin in general?
+			case "windows" :
+				slop *= 10 // Be forgiving of running in a VM
+			}
+			assertDurationEq(t, tcinfo.Expected, actual, slop)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/internal/sigint/sigint_unix.go
+++ b/internal/sigint/sigint_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package sigint
+
+import (
+	"os"
+)
+
+func SendInterrupt(proc *os.Process) error {
+	return proc.Signal(os.Interrupt)
+}

--- a/internal/sigint/sigint_windows.go
+++ b/internal/sigint/sigint_windows.go
@@ -1,0 +1,16 @@
+package sigint
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func SendInterrupt(proc *os.Process) error {
+	err := windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(proc.Pid))
+	if err != nil {
+		return &os.SyscallError{Syscall: "GenerateConsoleCtrlEvent", Err: err}
+	}
+	return nil
+}


### PR DESCRIPTION
Three things are happening here:
 - Have CI run the tests on `GOOS=windows` and `GOOS=darwin` (not just `GOOS=linux`)
 - Update the tests to work on `GOOS=windows` and `GOOS=darwin`.
 - There only turned out to be 1 portability problem in the actual code: `dexec` soft shutdown didn't work on Windows; so fix that (Windows doesn't have SIGINT; emulate it with syscall.CTRL_BREAK_EVENT).

IDK what's going on with coveralls flopping between whether it wants to turn green or not.  This PR *does* lower the reported test coverage percentage (from  87.932% to 86.907%) so it _should_ be turning red.  But the reason the percentage is going down is because of the added `if runtime.GOOS == "windows" { … }` blocks; the coverage report is based on the `GOOS=linux` run, so adding any code that doesn't run on `GOOS=linux` will make the reported percentage go down, even if that code is covered.