### PR TITLE
dlog: Defer sprintf to the final logger.

### DIFF
--- a/dlog/context.go
+++ b/dlog/context.go
@@ -4,7 +4,6 @@ package dlog
 
 import (
 	"context"
-	"fmt"
 	"log"
 )
 
@@ -62,29 +61,22 @@ func StdLogger(ctx context.Context, level LogLevel) *log.Logger {
 	return getLogger(ctx).StdLogger(level)
 }
 
-func sprintln(args ...interface{}) string {
-	// Trim the trailing newline; what we care about is that spaces are added in between
-	// arguments, not that there's a trailing newline.  See also: logrus.Entry.sprintlnn
-	msg := fmt.Sprintln(args...)
-	return msg[:len(msg)-1]
-}
-
 // If you change any of these, you should also change convenience.go.gen and run `make generate`.
 
 func Log(ctx context.Context, lvl LogLevel, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(lvl, fmt.Sprint(args...))
+	l.Log(lvl, args...)
 }
 
 func Logln(ctx context.Context, lvl LogLevel, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(lvl, sprintln(args...))
+	l.Logln(lvl, args...)
 }
 
 func Logf(ctx context.Context, lvl LogLevel, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(lvl, fmt.Sprintf(format, args...))
+	l.Logf(lvl, format, args...)
 }

--- a/dlog/convenience.go
+++ b/dlog/convenience.go
@@ -4,111 +4,110 @@ package dlog
 
 import (
 	"context"
-	"fmt"
 )
 
 func Error(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelError, fmt.Sprint(args...))
+	l.Log(LogLevelError, args...)
 }
 func Errorln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelError, sprintln(args...))
+	l.Logln(LogLevelError, args...)
 }
 func Errorf(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelError, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelError, format, args...)
 }
 func Warn(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, fmt.Sprint(args...))
+	l.Log(LogLevelWarn, args...)
 }
 func Warnln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, sprintln(args...))
+	l.Logln(LogLevelWarn, args...)
 }
 func Warnf(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelWarn, format, args...)
 }
 func Info(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, fmt.Sprint(args...))
+	l.Log(LogLevelInfo, args...)
 }
 func Infoln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, sprintln(args...))
+	l.Logln(LogLevelInfo, args...)
 }
 func Infof(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelInfo, format, args...)
 }
 func Debug(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelDebug, fmt.Sprint(args...))
+	l.Log(LogLevelDebug, args...)
 }
 func Debugln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelDebug, sprintln(args...))
+	l.Logln(LogLevelDebug, args...)
 }
 func Debugf(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelDebug, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelDebug, format, args...)
 }
 func Trace(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelTrace, fmt.Sprint(args...))
+	l.Log(LogLevelTrace, args...)
 }
 func Traceln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelTrace, sprintln(args...))
+	l.Logln(LogLevelTrace, args...)
 }
 func Tracef(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelTrace, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelTrace, format, args...)
 }
 func Print(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, fmt.Sprint(args...))
+	l.Log(LogLevelInfo, args...)
 }
 func Println(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, sprintln(args...))
+	l.Logln(LogLevelInfo, args...)
 }
 func Printf(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelInfo, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelInfo, format, args...)
 }
 func Warning(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, fmt.Sprint(args...))
+	l.Log(LogLevelWarn, args...)
 }
 func Warningln(ctx context.Context, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, sprintln(args...))
+	l.Logln(LogLevelWarn, args...)
 }
 func Warningf(ctx context.Context, format string, args ...interface{}) {
 	l := getLogger(ctx)
 	l.Helper()
-	l.Log(LogLevelWarn, fmt.Sprintf(format, args...))
+	l.Logf(LogLevelWarn, format, args...)
 }

--- a/dlog/convenience.go.gen
+++ b/dlog/convenience.go.gen
@@ -20,7 +20,6 @@
 
 	import (
 		"context"
-		"fmt"
 	)
 	EOT
 	emit() {
@@ -31,24 +30,26 @@
 		func ${lvlAlias}(ctx context.Context, args ...interface{}) {
 			l := getLogger(ctx)
 			l.Helper()
-			l.Log(LogLevel${lvlReal}, fmt.Sprint(args...))
+			l.Log(LogLevel${lvlReal}, args...)
 		}
 		func ${lvlAlias}ln(ctx context.Context, args ...interface{}) {
 			l := getLogger(ctx)
 			l.Helper()
-			l.Log(LogLevel${lvlReal}, sprintln(args...))
+			l.Logln(LogLevel${lvlReal}, args...)
 		}
 		func ${lvlAlias}f(ctx context.Context, format string, args ...interface{}) {
 			l := getLogger(ctx)
 			l.Helper()
-			l.Log(LogLevel${lvlReal}, fmt.Sprintf(format, args...))
+			l.Logf(LogLevel${lvlReal}, format, args...)
 		}
 		EOT
 	}
 	for lvl in "${levels[@]}"; do
 		emit "$lvl" "$lvl"
 	done
-	for alvl in "${!aliases[@]}"; do
+    # Sort the keys of aliases so we're sure the methods are always generated in the same order
+    mapfile -d '' sorted < <(printf '%s\0' "${!aliases[@]}" | sort -z)
+	for alvl in "${sorted[@]}"; do
 		emit "$alvl" "${aliases[${alvl}]}"
 	done
 } | gofmt

--- a/dlog/dlog_test.go
+++ b/dlog/dlog_test.go
@@ -150,7 +150,19 @@ func (l testLogger) WithField(key string, value interface{}) dlog.Logger {
 func (l testLogger) StdLogger(dlog.LogLevel) *log.Logger {
 	panic("not implemented")
 }
-func (l testLogger) Log(lvl dlog.LogLevel, msg string) {
+
+func (l testLogger) Logln(level dlog.LogLevel, args ...interface{}) {
+	msg := fmt.Sprintln(args...)
+	msg = msg[:len(msg)-1]
+	l.Log(level, msg)
+}
+
+func (l testLogger) Logf(level dlog.LogLevel, format string, args ...interface{}) {
+	l.Log(level, fmt.Sprintf(format, args...))
+}
+
+func (l testLogger) Log(lvl dlog.LogLevel, args ...interface{}) {
+	msg := fmt.Sprint(args...)
 	entry := testLogEntry{
 		level:   lvl,
 		message: msg,

--- a/dlog/logger.go
+++ b/dlog/logger.go
@@ -47,7 +47,13 @@ type Logger interface {
 	StdLogger(LogLevel) *log.Logger
 
 	// Log actually logs a message.
-	Log(level LogLevel, msg string)
+	Log(level LogLevel, args ...interface{})
+
+	// Logf logs a formatted message
+	Logf(level LogLevel, format string, args ...interface{})
+
+	// Logln logs the arguments given with a space in between each
+	Logln(level LogLevel, args ...interface{})
 }
 
 // LogLevel is an abstracted common log-level type for Logger.StdLogger().

--- a/dlog/logger_logrus.go
+++ b/dlog/logger_logrus.go
@@ -14,6 +14,8 @@ type logrusLogger interface {
 	WithField(key string, value interface{}) *logrus.Entry
 	WriterLevel(level logrus.Level) *io.PipeWriter
 	Log(level logrus.Level, args ...interface{})
+	Logln(level logrus.Level, args ...interface{})
+	Logf(level logrus.Level, format string, args ...interface{})
 }
 
 type logrusWrapper struct {
@@ -43,12 +45,28 @@ func (l logrusWrapper) StdLogger(level LogLevel) *log.Logger {
 	return log.New(l.logrusLogger.WriterLevel(logrusLevel), "", 0)
 }
 
-func (l logrusWrapper) Log(level LogLevel, msg string) {
+func (l logrusWrapper) Log(level LogLevel, args ...interface{}) {
 	logrusLevel, ok := dlogLevel2logrusLevel[level]
 	if !ok {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	l.logrusLogger.Log(logrusLevel, msg)
+	l.logrusLogger.Log(logrusLevel, args...)
+}
+
+func (l logrusWrapper) Logf(level LogLevel, format string, args ...interface{}) {
+	logrusLevel, ok := dlogLevel2logrusLevel[level]
+	if !ok {
+		panic(errors.Errorf("invalid LogLevel: %d", level))
+	}
+	l.logrusLogger.Logf(logrusLevel, format, args...)
+}
+
+func (l logrusWrapper) Logln(level LogLevel, args ...interface{}) {
+	logrusLevel, ok := dlogLevel2logrusLevel[level]
+	if !ok {
+		panic(errors.Errorf("invalid LogLevel: %d", level))
+	}
+	l.logrusLogger.Logln(logrusLevel, args...)
 }
 
 // WrapLogrus converts a logrus *Logger into a generic Logger.

--- a/dlog/logger_testing.go
+++ b/dlog/logger_testing.go
@@ -31,8 +31,26 @@ func (w tbWrapper) WithField(key string, value interface{}) Logger {
 	return ret
 }
 
-func (w tbWrapper) Log(level LogLevel, msg string) {
+func sprintln(args ...interface{}) string {
+	// Trim the trailing newline; what we care about is that spaces are added in between
+	// arguments, not that there's a trailing newline.  See also: logrus.Entry.sprintlnn
+	msg := fmt.Sprintln(args...)
+	return msg[:len(msg)-1]
+}
+
+func (w tbWrapper) Logln(level LogLevel, args ...interface{}) {
 	w.Helper()
+	w.Log(level, sprintln(args...))
+}
+
+func (w tbWrapper) Logf(level LogLevel, format string, args ...interface{}) {
+	w.Helper()
+	w.Log(level, fmt.Sprintf(format, args...))
+}
+
+func (w tbWrapper) Log(level LogLevel, args ...interface{}) {
+	w.Helper()
+	msg := fmt.Sprint(args...)
 	fields := make(map[string]interface{}, len(w.fields)+2)
 	for k, v := range w.fields {
 		fields[k] = v


### PR DESCRIPTION
This is intended to preserve CPU cycles that would otherwise be spent
formatting messages that will never be logged (e.g. formatting debug
messages when the log level is info)

Signed-off-by: Jose Cortes <josecortes@datawire.io>