### PR TITLE
Implement derror.MultiError

### DIFF
--- a/derror/multierror.go
+++ b/derror/multierror.go
@@ -50,6 +50,9 @@ func (errs MultiError) Error() string {
 			prefix := fmt.Sprintf("\n %d. ", i+1)
 			for j, line := range strings.SplitAfter(err.Error(), "\n") {
 				if j == 1 {
+					// After the first line (j==0), change the prefix to just be
+					// spaces.  Exclude the leading "\n" from the prefix because
+					// .SplitAfter leaves each line with a trailing "\n".
 					prefix = strings.Repeat(" ", len(prefix)-1)
 				}
 				buf.WriteString(prefix)

--- a/derror/multierror.go
+++ b/derror/multierror.go
@@ -1,0 +1,70 @@
+package derror
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MultiError is an `error` type that represents a list of errors.
+//
+// Yes, another one.  What's wrong with all of the existing ones?  Looking at the ones that Emissary
+// already imports:
+//
+//  - `github.com/asaskevich/govalidator.Errors` : (1) Doesn't implement .Is().  (2) Output is all
+//    on one line and hard to read.
+//
+//  - `github.com/getkin/kin-openapi/openapi3.MultiError` : Output is all on one line and hard to
+//    read.
+//
+//  - `github.com/prometheus/client_golang/prometheus.MultiError` : (1) Doesn't implement .Is().
+//    (2) Output is pretty good, but doesn't handle child errors having newlines in them.
+//
+//  - `google.golang.org/appengine.MultiError` : (1) Doesn't implement .Is().  (2) Output is
+//    "helpfully" summarized to only print the first error and then say "(and X other errors)".
+//
+//  - `k8s.io/apimachinery/pkg/util/errors.Aggregate` : (1) Output is all on one line and hard to
+//    read.  (2) Isn't a simple []error type, and so is clunky to work with.
+//
+//  - `sigs.k8s.io/controller-tools/pkg/loader.ErrList` : (1) Doesn't implement .Is().  (2) Output
+//    is all on one line and hard to read.
+//
+// Note that (like k8s.io/apimachinery/pkg/util/errors.Aggregate) we don't implement .As(), because
+// we buy in to the same justification:
+//
+//   // Errors.As() is not supported, because the caller presumably cares about a
+//   // specific error of potentially multiple that match the given type.
+type MultiError []error
+
+func (errs MultiError) Error() string {
+	switch len(errs) {
+	case 0:
+		// This should not happen.
+		return "(0 errors; BUG: this should not be reported as an error)"
+	case 1:
+		return errs[0].Error()
+	default:
+		var buf strings.Builder
+		fmt.Fprintf(&buf, "%d errors:", len(errs))
+		for i, err := range errs {
+			prefix := fmt.Sprintf("\n %d. ", i+1)
+			for j, line := range strings.SplitAfter(err.Error(), "\n") {
+				if j == 1 {
+					prefix = strings.Repeat(" ", len(prefix)-1)
+				}
+				buf.WriteString(prefix)
+				buf.WriteString(line)
+			}
+		}
+		return buf.String()
+	}
+}
+
+func (errs MultiError) Is(target error) bool {
+	for _, err := range errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/derror/multierror_test.go
+++ b/derror/multierror_test.go
@@ -1,0 +1,39 @@
+package derror_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/datawire/dlib/derror"
+)
+
+func TestMultiError(t *testing.T) {
+	err := derror.MultiError{
+		errors.New("first error"),
+		errors.New("second\nerror"),
+		errors.New("third error"),
+		errors.New("fourth error"),
+		errors.New("fifth error"),
+		errors.New("sixth error"),
+		errors.New("7th error"),
+		errors.New("8th error"),
+		errors.New("9th error"),
+		errors.New("tenth\nerror"),
+	}
+	exp := `10 errors:
+ 1. first error
+ 2. second
+    error
+ 3. third error
+ 4. fourth error
+ 5. fifth error
+ 6. sixth error
+ 7. 7th error
+ 8. 8th error
+ 9. 9th error
+ 10. tenth
+     error`
+	assert.Equal(t, exp, err.Error())
+}

--- a/derror/multierror_test.go
+++ b/derror/multierror_test.go
@@ -2,6 +2,8 @@ package derror_test
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,19 +12,43 @@ import (
 )
 
 func TestMultiError(t *testing.T) {
-	err := derror.MultiError{
-		errors.New("first error"),
-		errors.New("second\nerror"),
-		errors.New("third error"),
-		errors.New("fourth error"),
-		errors.New("fifth error"),
-		errors.New("sixth error"),
-		errors.New("7th error"),
-		errors.New("8th error"),
-		errors.New("9th error"),
-		errors.New("tenth\nerror"),
+	type testcase struct {
+		Input          derror.MultiError
+		ExpectedString string
+		ExpectedIs     []error
+		ExpectedIsNot  []error
 	}
-	exp := `10 errors:
+	testcases := map[string]testcase{
+		"nil": {
+			Input:          nil,
+			ExpectedString: "(0 errors; BUG: this should not be reported as an error)",
+		},
+		"zero": {
+			Input:          derror.MultiError{},
+			ExpectedString: "(0 errors; BUG: this should not be reported as an error)",
+		},
+		"one": {
+			Input: derror.MultiError{
+				fmt.Errorf("just my luck: %w", io.EOF),
+			},
+			ExpectedString: "just my luck: EOF",
+			ExpectedIs:     []error{io.EOF},
+			ExpectedIsNot:  []error{errors.New("EOD")},
+		},
+		"newlines": {
+			Input: derror.MultiError{
+				errors.New("first error"),
+				errors.New("second\nerror"),
+				errors.New("third error"),
+				errors.New("fourth error"),
+				errors.New("fifth error"),
+				errors.New("sixth error"),
+				errors.New("7th error"),
+				errors.New("8th error"),
+				errors.New("9th error"),
+				errors.New("tenth\nerror"),
+			},
+			ExpectedString: `10 errors:
  1. first error
  2. second
     error
@@ -34,6 +60,19 @@ func TestMultiError(t *testing.T) {
  8. 8th error
  9. 9th error
  10. tenth
-     error`
-	assert.Equal(t, exp, err.Error())
+     error`,
+		},
+	}
+	for tcName, tcData := range testcases {
+		tcData := tcData
+		t.Run(tcName, func(t *testing.T) {
+			assert.Equal(t, tcData.ExpectedString, tcData.Input.Error())
+			for i, err := range tcData.ExpectedIs {
+				assert.Truef(t, errors.Is(tcData.Input, err), ".ExpectedIs[i]", i)
+			}
+			for i, err := range tcData.ExpectedIsNot {
+				assert.Falsef(t, errors.Is(tcData.Input, err), ".ExpectedIsNot[i]", i)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I've implemented this enough times in different places that I should just implement it once and for all.  This particular implementation is based on the one from https://github.com/emissary-ingress/emissary 's `py-mkopensource`.