### PR TITLE
Add a LoggerWithMaxLevel interface

### DIFF
--- a/dlog/context.go
+++ b/dlog/context.go
@@ -65,6 +65,16 @@ func StdLogger(ctx context.Context, level LogLevel) *log.Logger {
 	return getLogger(ctx).StdLogger(level)
 }
 
+// MaxLogLevel returns the maximum loglevel of the Logger associated
+// with the ctx if that logger implements the LoggerWithMaxLevel interface,
+// or the highest possible level (LogLevelTrace) if it doesn't.
+func MaxLogLevel(ctx context.Context) LogLevel {
+	if lm, ok := getLogger(ctx).(LoggerWithMaxLevel); ok {
+		return lm.MaxLevel()
+	}
+	return LogLevelTrace
+}
+
 func sprintln(args ...interface{}) string {
 	// Trim the trailing newline; what we care about is that spaces are added in between
 	// arguments, not that there's a trailing newline.  See also: logrus.Entry.sprintlnn

--- a/dlog/logger.go
+++ b/dlog/logger.go
@@ -84,6 +84,19 @@ type OptimizedLogger interface {
 	UnformattedLogf(level LogLevel, format string, args ...interface{})
 }
 
+// LoggerWithMaxLevel can be implemented by loggers that define a maximum
+// level that will be logged, i.e. if a logger defines a max-level of
+// LogLevelInfo, then only LogLevelError, LogLevelWarn, and LogLevelInfo will
+// be logged, and LogLevelDebug and LogLevelTrace will be discarded.
+//
+// This interface can be used for examining what the loggers max level is
+// so that resource consuming string formatting can be avoided if its known that
+// the resulting message will be discarded anyway.
+type LoggerWithMaxLevel interface {
+	// MaxLevel return the maximum loglevel that will be logged
+	MaxLevel() LogLevel
+}
+
 // LogLevel is an abstracted common log-level type for Logger.StdLogger().
 type LogLevel uint32
 

--- a/dlog/logger.go
+++ b/dlog/logger.go
@@ -85,13 +85,28 @@ type OptimizedLogger interface {
 }
 
 // LoggerWithMaxLevel can be implemented by loggers that define a maximum
-// level that will be logged, i.e. if a logger defines a max-level of
+// level that will be logged, e.g. if a logger defines a max-level of
 // LogLevelInfo, then only LogLevelError, LogLevelWarn, and LogLevelInfo will
-// be logged, and LogLevelDebug and LogLevelTrace will be discarded.
+// be logged; while LogLevelDebug and LogLevelTrace will be discarded.
 //
 // This interface can be used for examining what the loggers max level is
-// so that resource consuming string formatting can be avoided if its known that
-// the resulting message will be discarded anyway.
+// so that resource consuming string formatting can be avoided if its known
+// that the resulting message will be discarded anyway.
+//
+// The MaxLevel method is provided in an extra interface for two reasons:
+//
+// 1. Expected implementations of OptimizedLogger that don't need a
+// MaxLevel, such as a wrapper for log.Logger.
+//
+// 2. A concern about performance degradation in existing implementations
+// when checks like:
+//
+//      if opt, ok := l.(OptimizedLogger); ok {
+//          ...
+//      }
+//
+// no longer detect implementations that lack the MaxLevel method and
+// silently choose a non-optimized approach.
 type LoggerWithMaxLevel interface {
 	// MaxLevel return the maximum loglevel that will be logged
 	MaxLevel() LogLevel

--- a/dlog/logger_logrus.go
+++ b/dlog/logger_logrus.go
@@ -53,6 +53,20 @@ func (l logrusWrapper) Log(level LogLevel, msg string) {
 	l.logrusLogger.Log(dlogLevel2logrusLevel[level], msg)
 }
 
+func (l logrusWrapper) MaxLevel() LogLevel {
+	ll := l.logrusLogger
+	if le, ok := ll.(*logrus.Entry); ok {
+		ll = le.Logger
+	}
+	logrusLevel := ll.(*logrus.Logger).GetLevel()
+	for i, l := range dlogLevel2logrusLevel {
+		if l == logrusLevel {
+			return LogLevel(i)
+		}
+	}
+	panic(errors.Errorf("invalid logrus LogLevel: %d", logrusLevel))
+}
+
 func (l logrusWrapper) UnformattedLog(level LogLevel, args ...interface{}) {
 	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))

--- a/dlog/logger_logrus.go
+++ b/dlog/logger_logrus.go
@@ -31,52 +31,47 @@ func (l logrusWrapper) WithField(key string, value interface{}) Logger {
 	return logrusWrapper{l.logrusLogger.WithField(key, value)}
 }
 
-var dlogLevel2logrusLevel = map[LogLevel]logrus.Level{
-	LogLevelError: logrus.ErrorLevel,
-	LogLevelWarn:  logrus.WarnLevel,
-	LogLevelInfo:  logrus.InfoLevel,
-	LogLevelDebug: logrus.DebugLevel,
-	LogLevelTrace: logrus.TraceLevel,
+var dlogLevel2logrusLevel = [5]logrus.Level{
+	logrus.ErrorLevel,
+	logrus.WarnLevel,
+	logrus.InfoLevel,
+	logrus.DebugLevel,
+	logrus.TraceLevel,
 }
 
 func (l logrusWrapper) StdLogger(level LogLevel) *log.Logger {
-	logrusLevel, ok := dlogLevel2logrusLevel[level]
-	if !ok {
+	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	return log.New(l.logrusLogger.WriterLevel(logrusLevel), "", 0)
+	return log.New(l.logrusLogger.WriterLevel(dlogLevel2logrusLevel[level]), "", 0)
 }
 
 func (l logrusWrapper) Log(level LogLevel, msg string) {
-	logrusLevel, ok := dlogLevel2logrusLevel[level]
-	if !ok {
+	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	l.logrusLogger.Log(logrusLevel, msg)
+	l.logrusLogger.Log(dlogLevel2logrusLevel[level], msg)
 }
 
 func (l logrusWrapper) UnformattedLog(level LogLevel, args ...interface{}) {
-	logrusLevel, ok := dlogLevel2logrusLevel[level]
-	if !ok {
+	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	l.logrusLogger.Log(logrusLevel, args...)
+	l.logrusLogger.Log(dlogLevel2logrusLevel[level], args...)
 }
 
 func (l logrusWrapper) UnformattedLogln(level LogLevel, args ...interface{}) {
-	logrusLevel, ok := dlogLevel2logrusLevel[level]
-	if !ok {
+	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	l.logrusLogger.Logln(logrusLevel, args...)
+	l.logrusLogger.Logln(dlogLevel2logrusLevel[level], args...)
 }
 
 func (l logrusWrapper) UnformattedLogf(level LogLevel, format string, args ...interface{}) {
-	logrusLevel, ok := dlogLevel2logrusLevel[level]
-	if !ok {
+	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))
 	}
-	l.logrusLogger.Logf(logrusLevel, format, args...)
+	l.logrusLogger.Logf(dlogLevel2logrusLevel[level], format, args...)
 }
 
 // WrapLogrus converts a logrus *Logger into a generic Logger.


### PR DESCRIPTION
This interface is meant to be used by `Logger` implementations that
will discard messages above a certain log level. A prominent example
is the current logrus wrapper.

The interface is motivated by the need to sometimes skip resource
consuming string formatting for messages that the logger will discard.
Example:

    if dlog.MaxLogLevel(ctx) >= dlog.LogLevelTrace {
      // use a string buffer to build a trace message from some network
      // package, then log it with
      dlog.Trace(ctx, msg)
    }

The max-level can also be usedful when an alternative logger must
be created for some third party module that implements its own logger
API.