### PR TITLE
Add SetMaxLogLevel method to LoggerWithMaxLevel interface

### DIFF
--- a/dlog/context.go
+++ b/dlog/context.go
@@ -75,6 +75,18 @@ func MaxLogLevel(ctx context.Context) LogLevel {
 	return LogLevelTrace
 }
 
+// SetMaxLogLevel sets the maximum loglevel of the Logger associated
+// with ctx if that logger implements the LoggerWithMaxLevel interface,
+// otherwise it does nothing.
+//
+// Note that the loglevel set will remain with future calls to dlog.Log
+// using the same ctx. 
+func SetMaxLogLevel(ctx context.Context, level LogLevel){
+	if lm, ok := getLogger(ctx).(LoggerWithMaxLevel); ok {
+		lm.SetMaxLevel(level)
+	}
+}
+
 func sprintln(args ...interface{}) string {
 	// Trim the trailing newline; what we care about is that spaces are added in between
 	// arguments, not that there's a trailing newline.  See also: logrus.Entry.sprintlnn

--- a/dlog/dlog_test.go
+++ b/dlog/dlog_test.go
@@ -152,29 +152,29 @@ func TestInvalidLogLevel(t *testing.T) {
 	}
 }
 
-var dlogLevel2logrusLevel = map[dlog.LogLevel]logrus.Level{
-	dlog.LogLevelError: logrus.ErrorLevel,
-	dlog.LogLevelWarn:  logrus.WarnLevel,
-	dlog.LogLevelInfo:  logrus.InfoLevel,
-	dlog.LogLevelDebug: logrus.DebugLevel,
-	dlog.LogLevelTrace: logrus.TraceLevel,
+var dlogLevel2logrusLevel = [5]dlog.LogLevel{
+	dlog.LogLevelError,
+	dlog.LogLevelWarn,
+	dlog.LogLevelInfo,
+	dlog.LogLevelDebug,
+	dlog.LogLevelTrace,
 }
 
 func TestMaxLevel(t *testing.T) {
-	for d, r := range dlogLevel2logrusLevel {
+	for _, d := range dlogLevel2logrusLevel {
 		logger := logrus.New()
-		logger.SetLevel(r)
 		ctx := dlog.WithLogger(context.Background(), dlog.WrapLogrus(logger))
+		dlog.SetMaxLogLevel(ctx, d)
 		assert.Equal(t, d, dlog.MaxLogLevel(ctx))
 	}
 }
 
 func TestMaxLevelWithField(t *testing.T) {
-	for d, r := range dlogLevel2logrusLevel {
+	for _, d := range dlogLevel2logrusLevel {
 		logger := logrus.New()
-		logger.SetLevel(r)
 		ctx := dlog.WithLogger(context.Background(), dlog.WrapLogrus(logger))
 		ctx = dlog.WithField(ctx, "testing", "test field")
+		dlog.SetMaxLogLevel(ctx, d)
 		assert.Equal(t, d, dlog.MaxLogLevel(ctx))
 	}
 }
@@ -195,6 +195,18 @@ func TestInvalidMaxLevel(t *testing.T) {
 		}
 	}()
 	dlog.MaxLogLevel(ctx)
+}
+
+func TestSetInvalidMaxLevel(t *testing.T) {
+	logger := logrus.New()
+	ctx := dlog.WithLogger(context.Background(), dlog.WrapLogrus(logger))
+	defer func() {
+		x := recover()
+		if x == nil {
+			t.Errorf("Setting invalid max level did not panic")
+		}
+	}()
+	dlog.SetMaxLogLevel(ctx, 999)
 }
 
 type testLogEntry struct {

--- a/dlog/logger.go
+++ b/dlog/logger.go
@@ -84,19 +84,23 @@ type OptimizedLogger interface {
 	UnformattedLogf(level LogLevel, format string, args ...interface{})
 }
 
-// LoggerWithMaxLevel can be implemented by loggers that define a maximum
-// level that will be logged, e.g. if a logger defines a max-level of
-// LogLevelInfo, then only LogLevelError, LogLevelWarn, and LogLevelInfo will
-// be logged; while LogLevelDebug and LogLevelTrace will be discarded.
+// LoggerWithMaxLevel can be implemented by loggers that support leveled logging
+// where a maximum level can be defined that will be logged, e.g. if a logger 
+// defines a max-level of LogLevelInfo, then only LogLevelError, LogLevelWarn, 
+// and LogLevelInfo will be logged; while LogLevelDebug and LogLevelTrace 
+// will be discarded.
 //
-// This interface can be used for examining what the loggers max level is
-// so that resource consuming string formatting can be avoided if its known
-// that the resulting message will be discarded anyway.
+// This interface can be used for setting and examining the logger's max level.
+// This is useful in situations where resources consuming string formatting 
+// can be avoided if its known that the resulting message will be discarded anyway
+// or if the log level needs to be dynamically set at runtime without being dependent
+// on a particular logger implementation.
 //
-// The MaxLevel method is provided in an extra interface for two reasons:
+// The MaxLevel and SetMaxLevel methods are provided in an extra interface
+// for two reasons:
 //
 // 1. Expected implementations of OptimizedLogger that don't need a
-// MaxLevel, such as a wrapper for log.Logger.
+// MaxLevel and SetMaxLevel, such as a wrapper for log.Logger.
 //
 // 2. A concern about performance degradation in existing implementations
 // when checks like:
@@ -105,11 +109,21 @@ type OptimizedLogger interface {
 //          ...
 //      }
 //
-// no longer detect implementations that lack the MaxLevel method and
-// silently choose a non-optimized approach.
+// no longer detect implementations that lack the MaxLevel or SetMaxLevel methods 
+// and silently choose a non-optimized approach.
 type LoggerWithMaxLevel interface {
-	// MaxLevel return the maximum loglevel that will be logged
+	// MaxLevel returns the maximum loglevel that will be logged. 
+	
+	// If the loglevel returned by the underlying logger is invalid
+	// (i.e has no corresponding dlog.LogLevel) then the function panics.
 	MaxLevel() LogLevel
+
+	// SetMaxLevel sets the maximum loglevel that will be logged
+	
+	// If level is invalid, then the function should panic to be 
+	// consistent with MaxLevel where it panics when an invalid 
+	// loglevel is returned by the underlying logger.
+	SetMaxLevel(level LogLevel)
 }
 
 // LogLevel is an abstracted common log-level type for Logger.StdLogger().

--- a/dlog/logger_logrus.go
+++ b/dlog/logger_logrus.go
@@ -67,6 +67,15 @@ func (l logrusWrapper) MaxLevel() LogLevel {
 	panic(errors.Errorf("invalid logrus LogLevel: %d", logrusLevel))
 }
 
+func (l logrusWrapper) SetMaxLevel(level LogLevel) {
+	ll := l.logrusLogger
+	if le, ok := ll.(*logrus.Entry); ok {
+		ll = le.Logger
+	}
+	logrusLevel := dlogLevel2logrusLevel[level]
+	ll.(*logrus.Logger).SetLevel(logrusLevel)
+}
+
 func (l logrusWrapper) UnformattedLog(level LogLevel, args ...interface{}) {
 	if level > LogLevelTrace {
 		panic(errors.Errorf("invalid LogLevel: %d", level))


### PR DESCRIPTION
Follow up to #39 

Propose to add `SetMaxLogLevel` to `LoggerWithMaxLevel` interface to complete the leveled logging add-in interface for loggers that support it or add leveled logging for logger implementations that don't natively support it. 

The main motivation is that there are situations where the loglevel wants to be set dynamically at runtime (ex. from an environment variable) but do not want to be dependent on a particular logging implementation or has to reference a global logger

An example is in emissary where logrus.Logger is exposed globally from the package

```golang
var logrusLogger *logrus.Logger
...

// Setting global state
func SetLogLevel(lvl logrus.Level) {
	logrusLogger.SetLevel(lvl)
}

// Getting package global state
func GetLogLevel() logrus.Level {
	return logrusLogger.GetLevel()
}
```

With this new method to the interface we can set the log level for the logger passed in through the context without being dependent on a particular implementation.
```golang
logger := dlog.WrapLogrus(logrusLogger).
ctx := dlog.WithLogger(context.Background(), logger)

// later on
doSomething(ctx) {
  switch os.Getenv("LOGLEVEL") {
      case "WARN":
        dlog.SetMaxLogLevel(ctx, dlog.LogLevelWarn)
      case "ERROR":
        dlog.SetMaxLogLevel(ctx, dlog.LogLevelError)
      default:
        dlog.SetMaxLogLevel(ctx, dlog.LogLevelInfo)
  }
  ...
}
```

I think this offers a cleaner api if we're passing loggers through context.
