### PR TITLE
Remove WithoutContext conflict and fix tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dlib.cov: test
 	test -e $@
 	touch $@
 test:
-	go test -count=1 -coverprofile=dlib.cov -coverpkg=./... -race ./...
+	GOCOVERDIR=. go test -count=1 -coverprofile=dlib.cov -coverpkg=./... -race ./...
 .PHONY: test
 
 %.cov.html: %.cov

--- a/dcontext/borrowed_context.go
+++ b/dcontext/borrowed_context.go
@@ -8,7 +8,7 @@
 package dcontext // MODIFIED: FROM: package context
 
 import (
-	. "context"           // MODIFIED: ADDED
+	"context"             // MODIFIED: ADDED
 	reflectlite "reflect" // MODIFIED: FROM: "internal/reflectlite"
 )
 
@@ -16,7 +16,7 @@ type stringer interface {
 	String() string
 }
 
-func contextName(c Context) string {
+func contextName(c context.Context) string {
 	if s, ok := c.(stringer); ok {
 		return s.String()
 	}

--- a/dcontext/hardsoft_example_test.go
+++ b/dcontext/hardsoft_example_test.go
@@ -2,6 +2,7 @@ package dcontext_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/datawire/dlib/dcontext"
@@ -10,9 +11,10 @@ import (
 
 // This should be a very simple example of a parent caller function, showing how
 // to manage a hard/soft Context and how to call code that is dcontext-aware.
-func Example_caller() error {
-	ctx := context.Background()                       // Context is hard by default
-	ctx, timeToDie := context.WithCancel(ctx)         // hard Context => hard cancel
+func ExampleWithSoftness() {
+	ctx := context.Background()               // Context is hard by default
+	ctx, timeToDie := context.WithCancel(ctx) // hard Context => hard cancel
+	defer timeToDie()
 	ctx = dcontext.WithSoftness(ctx)                  // make it soft
 	ctx, startShuttingDown := context.WithCancel(ctx) // soft Context => soft cancel
 
@@ -21,11 +23,11 @@ func Example_caller() error {
 		sc := &dhttp.ServerConfig{
 			// ...
 		}
-		retCh <- sc.ListenAndServe(ctx, ":http")
+		retCh <- sc.ListenAndServe(ctx, ":0")
 	}()
 
 	// Run for a while.
-	time.Sleep(10 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// Shut down.
 	startShuttingDown() // Soft shutdown; start draining connections.
@@ -34,13 +36,21 @@ func Example_caller() error {
 		// It shut down fine with just the soft shutdown; everything was
 		// well-behaved.  It isn't necessary to cut shutdown short by
 		// triggering a hard shutdown with timeToDie() in this case.
-		return err
-	case <-time.After(5 * time.Second): // shutdown grace period
+		if err != nil {
+			fmt.Println(err.Error())
+		} else {
+			fmt.Println("soft shutdown")
+		}
+	case <-time.After(2 * time.Second): // shutdown grace period
 		// It's taking too long to shut down--it seems that some clients
 		// are refusing to hang up.  So now we trigger a hard shutdown
 		// and forcefully close the connections.  This will cause errors
 		// for those clients.
 		timeToDie() // Hard shutdown; cause errors for clients
-		return <-retCh
+		if err := <-retCh; err != nil {
+			fmt.Println(err.Error())
+		}
 	}
+	// Output:
+	// soft shutdown
 }

--- a/dexec/logging_test.go
+++ b/dexec/logging_test.go
@@ -151,7 +151,7 @@ func TestOutputErrors(t *testing.T) {
 			ctx := newCapturingContext(t, &actualLog)
 
 			cmd := dexec.CommandContext(ctx, os.Args[0], "-test.run=TestLoggingHelperProcess")
-			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+			cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 			cmd.Stdout = tcData.InputStdout
 			cmd.Stderr = tcData.InputStderr
 
@@ -203,7 +203,7 @@ func TestLogging(t *testing.T) {
 			ctx := newCapturingContext(t, &actualLog)
 
 			cmd := dexec.CommandContext(ctx, os.Args[0], "-test.run=TestLoggingHelperProcess")
-			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+			cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 			cmd.Stdout = tcData.InputStdout
 			cmd.DisableLogging = tcData.InputDisableLogging
 

--- a/dexec/supervisor_test.go
+++ b/dexec/supervisor_test.go
@@ -86,14 +86,14 @@ func TestCommandRunLogging(t *testing.T) {
 	// I say "equivalent of", because we're doing this with Go, because not all platforms have
 	// Bash.
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestCommandRunLoggingHelperProcess")
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 	if err := cmd.Run(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	//nolint:lll
 	expectedLines := []string{
-		`level=info dexec.pid=XXPIDXX msg="started command [`+quote15(os.Args[0])+` \"-test.run=TestCommandRunLoggingHelperProcess\"]"`,
+		`level=info dexec.pid=XXPIDXX msg="started command [` + quote15(os.Args[0]) + ` \"-test.run=TestCommandRunLoggingHelperProcess\"]"`,
 		`level=info dexec.pid=XXPIDXX dexec.stream=stdin dexec.err=EOF`,
 		`level=info dexec.pid=XXPIDXX dexec.stream=stdout+stderr dexec.data="1\n"`,
 		`level=info dexec.pid=XXPIDXX dexec.stream=stdout+stderr dexec.data="2\n"`,


### PR DESCRIPTION
This PR removes the conflict caused by a dot import of "context" when the [WithoutContext](https://pkg.go.dev/context#WithoutCancel) method was introduced in the go runtime.

Apparently, the `GOCOVERDIR` must now also be set to run the tests.